### PR TITLE
v2.1.3: Code quality, documentation, and test improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Versions
 
+- [v2.1.3 - 2026-05-13](#v213---2026-05-13) _(Go 1.21+)_
 - [v2.1.2 - 2026-05-13](#v212---2026-05-13) _(Go 1.21+)_
 - [v2.1.1 - 2026-05-04](#v211---2026-05-04) _(Go 1.21+)_
 - [v2.1.0 - 2026-04-20](#v210---2026-04-20) _(Go 1.21+)_
@@ -21,6 +22,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [v1.0.1 - 2020-06-25](#v101---2020-06-25) _(Go 1.14+)_
 - [v1.0.0 - 2020-05-02](#v100---2020-05-02) _(Go 1.14+)_
 
+
+# v2.1.3 - 2026-05-13
+Code quality, documentation, and test improvements.
+
+### Added
+
+- Doc comments added to previously undocumented exported and internal symbols:
+  - `Tmap` type
+  - `ErrorSignedToUnsigned`, `ErrorInvalidOption`, `ErrorStrErrorCastingFunc`, `ErrorStrUnableToCast` (clarifying the string vars are format strings, not error values)
+  - `castToType` — all 8 dispatch cases documented
+- New godoc examples: `ExampleTo_map`, `ExampleTo_struct`, `ExampleToE_mapDuplicateKeyError`, `ExampleToE_structNested`, `ExampleToE_structStrict`, `ExampleToE_mapToPrivateStruct`.
+
+### Changed
+
+- Renamed the sentinel error variable `Error` to `ErrorUnableToCast`. `Error` is retained as a deprecated alias with a `// Deprecated:` godoc annotation for backward compatibility.
+- Example function suffixes converted from `snake_case` to `camelCase` (e.g. `ExampleToE_mapFromMap`) so all examples appear in godoc. Suffixes containing underscores are silently dropped by godoc.
+- `CLAUDE.md` trimmed to remove content derivable from the codebase; added environment notes (go binary path, shell alias caveat) and intentional limitation notes (array targets, `chan map[K]V`).
+
+### Fixed
+
+- `ToE` doc referenced non-existent type `Ops` (correct type is `Op`) and contained double word "the the" — corrected.
+- `ToStructE` doc omitted `*struct` as a valid source type — corrected.
+- `toSlice` doc was circular and meaningless — rewritten.
+- `ops.Global` doc omitted `FORMAT` from the global flag list and `DECODE` from the local flag list — corrected.
+- `parseOps` doc omitted `FORMAT` and `DECODE` from its description of preserved values — corrected.
+- `ops` struct doc incorrectly stated all non-default flags are pre-parsed to `bool`; `FORMAT` and `DECODE` are stored as strings — corrected.
+- `TestPointerDerefLoop` "pointer-to-interface" sub-test used `errors.New` whose concrete pointer type is opaque; replaced with a local `ptrReceiverError` type that has `Error()` on `*T` only, making the pointer-receiver guard explicit and self-documenting.
 
 # v2.1.2 - 2026-05-13
 Code quality, bug fixes, and internal refactoring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ Code quality, documentation, and test improvements.
 
 - Renamed the sentinel error variable `Error` to `ErrorUnableToCast`. `Error` is retained as a deprecated alias with a `// Deprecated:` godoc annotation for backward compatibility.
 - Example function suffixes converted from `snake_case` to `camelCase` (e.g. `ExampleToE_mapFromMap`) so all examples appear in godoc. Suffixes containing underscores are silently dropped by godoc.
-- `CLAUDE.md` trimmed to remove content derivable from the codebase; added environment notes (go binary path, shell alias caveat) and intentional limitation notes (array targets, `chan map[K]V`).
 
 ### Fixed
 

--- a/test.examples_test.go
+++ b/test.examples_test.go
@@ -11,7 +11,8 @@ func ExampleToE_string() {
 	fmt.Printf("%#v (%T), %v", v, v, e)
 	// Output: "1" (string), <nil>
 }
-func ExampleToE_error_with_default() {
+
+func ExampleToE_errorWithDefault() {
 	v, e := cast.ToE[int]("Hi!", cast.Op{cast.DEFAULT, 10})
 	fmt.Printf("%#v (%T), %v", v, v, e)
 	// Output: 10 (int), strconv.ParseFloat: parsing "Hi!": invalid syntax: strconv.ParseFloat: parsing "Hi!": invalid syntax: unable to cast "Hi!" of type string to int
@@ -35,13 +36,13 @@ func ExampleToE_int() {
 	// Output: 1 (int), <nil>
 }
 
-func ExampleToE_uint_err() {
+func ExampleToE_uintErr() {
 	v, e := cast.ToE[uint]("-1")
 	fmt.Printf("%v (%T), %v", v, v, e)
 	// Output: 0 (uint), cannot cast signed value to unsigned integer: unable to cast "-1" of type string to uint
 }
 
-func ExampleToE_uint_abs() {
+func ExampleToE_uintAbs() {
 	v, e := cast.ToE[uint]("-1", cast.Op{cast.ABS, true})
 	fmt.Printf("%v (%T), %v", v, v, e)
 	// Output: 1 (uint), <nil>
@@ -65,7 +66,7 @@ func ExampleTo_slice() {
 	// Output: [1 2 3] ([]int)
 }
 
-func ExampleToE_slice_unique_values() {
+func ExampleToE_sliceUniqueValues() {
 	v, e := cast.ToE[[]int]([]int{1, 2, 1, 3}, cast.Op{cast.UNIQUE_VALUES, true})
 	fmt.Printf("%v (%T), %v", v, v, e)
 	// Output: [1 2 3] ([]int), <nil>
@@ -78,7 +79,7 @@ func ExampleTo_chan() {
 	// Output: 10 (int)
 }
 
-func ExampleToE_chan_length() {
+func ExampleToE_chanLength() {
 	ch, e := cast.ToE[chan int](10, cast.Op{cast.LENGTH, 5})
 	v := <-ch
 	fmt.Printf("%v (cap %d), %v", v, cap(ch), e)
@@ -91,39 +92,102 @@ func ExampleTo_func() {
 	// Output: 10 (int)
 }
 
-func ExampleToE_map_from_map() {
+func ExampleTo_map() {
+	m := cast.To[map[string]int](map[string]string{"a": "1", "b": "2"})
+	fmt.Printf("a=%v b=%v (%T)", m["a"], m["b"], m)
+	// Output: a=1 b=2 (map[string]int)
+}
+
+func ExampleToE_mapFromMap() {
 	m, e := cast.ToE[map[string]int](map[string]string{"a": "1"})
 	fmt.Printf("%v (%T), %v", m["a"], m["a"], e)
 	// Output: 1 (int), <nil>
 }
 
-func ExampleToE_map_from_struct() {
+func ExampleToE_mapDuplicateKeyError() {
+	// After casting, "1" and "01" both become the integer key 1 — a duplicate.
+	m, e := cast.ToE[map[int]string](
+		map[string]string{"1": "one", "01": "also-one"},
+		cast.Op{cast.DUPLICATE_KEY_ERROR, true},
+	)
+	fmt.Printf("m=%v, err=%v", m, e != nil)
+	// Output: m=map[], err=true
+}
+
+func ExampleToE_mapFromStruct() {
 	type Point struct{ X, Y int }
 	m, e := cast.ToE[map[string]any](Point{X: 3, Y: 4})
 	fmt.Printf("X=%v Y=%v, %v", m["X"], m["Y"], e)
 	// Output: X=3 Y=4, <nil>
 }
 
-func ExampleToE_map_from_private_struct() {
+func ExampleToE_mapFromPrivateStruct() {
+	// PRIVATE includes unexported fields as map keys.
 	type Point struct{ x, y int }
 	m, e := cast.ToE[map[string]any](Point{x: 3, y: 4}, cast.Op{cast.PRIVATE, true})
 	fmt.Printf("x=%v y=%v, %v", m["x"], m["y"], e)
 	// Output: x=3 y=4, <nil>
 }
 
-func ExampleToE_map_from_slice() {
+func ExampleToE_mapToPrivateStruct() {
+	// PRIVATE allows map values to be written into unexported struct fields.
+	type Point struct{ x, y int }
+	p, e := cast.ToE[Point](map[string]any{"x": 3, "y": 4}, cast.Op{cast.PRIVATE, true})
+	fmt.Printf("x=%v y=%v (%T), %v", p.x, p.y, p, e)
+	// Output: x=3 y=4 (cast_test.Point), <nil>
+}
+
+func ExampleToE_mapFromSlice() {
 	m, e := cast.ToE[map[int]string]([]string{"a", "b", "c"})
 	fmt.Printf("%v (%T), %v", m[0], m[0], e)
 	// Output: a (string), <nil>
 }
 
-func ExampleToE_string_json() {
+func ExampleToE_stringJson() {
 	v, e := cast.ToE[string](`hello "world"`, cast.Op{cast.JSON, true})
 	fmt.Printf("%v, %v", v, e)
 	// Output: "hello \"world\"", <nil>
 }
 
-func ExampleToE_map_to_struct() {
+func ExampleTo_struct() {
+	type Point struct{ X, Y int }
+	p := cast.To[Point](map[string]any{"X": "3", "Y": "4"})
+	fmt.Printf("X=%v Y=%v (%T)", p.X, p.Y, p)
+	// Output: X=3 Y=4 (cast_test.Point)
+}
+
+func ExampleToE_structNested() {
+	type Address struct{ City, Country string }
+	type Person struct {
+		Name    string
+		Age     int
+		Address Address
+	}
+	m := map[string]any{
+		"Name": "Alice",
+		"Age":  "30",
+		"Address": map[string]any{
+			"City":    "Portland",
+			"Country": "US",
+		},
+	}
+	p, e := cast.ToE[Person](m)
+	fmt.Printf("Name=%v Age=%v City=%v Country=%v, %v", p.Name, p.Age, p.Address.City, p.Address.Country, e)
+	// Output: Name=Alice Age=30 City=Portland Country=US, <nil>
+}
+
+func ExampleToE_structStrict() {
+	type Point struct{ X, Y int }
+	// "Z" has no matching field in Point — STRICT turns that into an error.
+	_, e := cast.ToE[Point](
+		map[string]any{"X": 1, "Y": 2, "Z": 3},
+		cast.Op{cast.STRICT, true},
+	)
+	fmt.Printf("err=%v", e != nil)
+	// Output: err=true
+}
+
+func ExampleToE_mapToStruct() {
 	type MyStruct struct {
 		X int
 		Y int
@@ -144,7 +208,7 @@ func ExampleToE_map_to_struct() {
 	// Output: p=(cast_test.MyStruct), X=3 (int), Y=4 (int), A=hello (string), B=world (string), <nil>
 }
 
-func ExampleToE_struct_to_struct() {
+func ExampleToE_structToStruct() {
 	type MyStruct struct {
 		X int
 		Y int
@@ -168,7 +232,7 @@ func ExampleToE_struct_to_struct() {
 	// Output: p=(cast_test.MyStruct), X=3 (int), Y=4 (int), A=hello (string), B=world (string), <nil>
 }
 
-func ExampleToE_map_to_struct_tags() {
+func ExampleToE_mapToStructTags() {
 	type MyStruct struct {
 		X int    `cast:"field_x"`
 		Y int    `cast:"field_y"`
@@ -186,7 +250,7 @@ func ExampleToE_map_to_struct_tags() {
 	// Output: p=(cast_test.MyStruct), X=3 (int), Y=4 (int), A=hello (string), B=world (string), <nil>
 }
 
-func ExampleToE_struct_to_struct_private() {
+func ExampleToE_structToStructPrivate() {
 	type MyStruct struct {
 		X int
 		Y int
@@ -210,7 +274,7 @@ func ExampleToE_struct_to_struct_private() {
 	// Output: p=(cast_test.MyStruct), X=3 (int), Y=4 (int), a=hello (string), b=world (string), <nil>
 }
 
-func ExampleToE_struct_to_struct_json_tags() {
+func ExampleToE_structToStructJsonTags() {
 	type MyStruct struct {
 		X int    `json:"fieldX"`
 		Y int    `json:"fieldY"`
@@ -234,7 +298,7 @@ func ExampleToE_struct_to_struct_json_tags() {
 	// Output: p=(cast_test.MyStruct), X=3 (int), Y=4 (int), a=hello (string), b=world (string), <nil>
 }
 
-func ExampleToE_struct_to_map() {
+func ExampleToE_structToMap() {
 	type YourStruct struct {
 		X int
 		Y int
@@ -255,7 +319,7 @@ func ExampleToE_struct_to_map() {
 	// Output: p=(map[string]string), X=3 (string), Y=4 (string), A=hello (string), B=world (string), <nil>
 }
 
-func ExampleToE_struct_to_map_error() {
+func ExampleToE_structToMapError() {
 	type YourStruct struct {
 		X int
 		Y int
@@ -286,25 +350,3 @@ type Output struct {
 func (o Output) Get(field string) any {
 	return ""
 }
-
-// func ExampleToE_generic() {
-// 	type Input struct {
-// 		X int
-// 		Y int
-// 		a string
-// 		b string
-// 	}
-
-// 	input := Input{
-// 		X: 3,
-// 		Y: 4,
-// 		a: "hello",
-// 		b: "world",
-// 	}
-// 	data := []Output{}
-// 	output, e := cast.ToE[Output](input, cast.Op{cast.PRIVATE, true})
-// 	data = append(data, output)
-
-// 	fmt.Printf("data=(%T), fieldX=%v (%T), fieldY=%v (%T), fieldA=%v (%T), fieldB=%v (%T), %v", data[0], data[0].fieldX, data[0].fieldX, data[0].fieldY, data[0].fieldY, data[0].fieldA, data[0].fieldA, data[0].fieldB, data[0].fieldB, e)
-// 	// Output: data=(cast_test.Output), fieldX=3 (string), fieldY=4 (int), fieldA=hello (string), fieldB=world (string), <nil>
-// }

--- a/test.options_test.go
+++ b/test.options_test.go
@@ -341,7 +341,7 @@ func TestChanLengthInvalidType(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for non-int LENGTH value on chan, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
+	if !errors.Is(err, cast.ErrorUnableToCast) {
 		t.Errorf("expected cast.Error, got %v", err)
 	}
 }

--- a/test.options_test.go
+++ b/test.options_test.go
@@ -342,7 +342,7 @@ func TestChanLengthInvalidType(t *testing.T) {
 		t.Error("expected error for non-int LENGTH value on chan, got nil")
 	}
 	if !errors.Is(err, cast.ErrorUnableToCast) {
-		t.Errorf("expected cast.Error, got %v", err)
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 

--- a/test.panic_test.go
+++ b/test.panic_test.go
@@ -30,8 +30,8 @@ func TestToERecoversPanicWithErrorValue(t *testing.T) {
 	if err == nil {
 		t.Error("expected error from recovered error-panic, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 	if result != "" {
 		t.Errorf("expected zero value on panic, got %q", result)
@@ -45,8 +45,8 @@ func TestToERecoversPanic(t *testing.T) {
 		if err == nil {
 			t.Error("expected error from recovered panic, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 		if result != "" {
 			t.Errorf("expected zero value on panic, got %q", result)
@@ -58,8 +58,8 @@ func TestToERecoversPanic(t *testing.T) {
 		if err == nil {
 			t.Error("expected error from recovered panic, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 		if result != false {
 			t.Errorf("expected zero value on panic, got %v", result)

--- a/to.big_test.go
+++ b/to.big_test.go
@@ -53,8 +53,8 @@ func TestToEBigInt(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && result.String() != tc.expectStr {
 				t.Errorf("expected %s, got %s", tc.expectStr, result.String())
 			}
@@ -152,8 +152,8 @@ func TestToEBigFloat(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && !eqStr(result, tc.expectStr) {
 				t.Errorf("expected %s, got %s", tc.expectStr, result.Text('f', -1))
 			}
@@ -243,8 +243,8 @@ func TestToEBigIntMissingCases(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for invalid big.Int string, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 }
@@ -285,8 +285,8 @@ func TestToEBigFloatMissingCases(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for invalid big.Float string, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 }
@@ -300,8 +300,8 @@ func TestDefaultBranchBigIntErrors(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for bool→*big.Int, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 	t.Run("complex128 → error (\"(1+2i)\" is not a valid big.Int)", func(t *testing.T) {
@@ -309,8 +309,8 @@ func TestDefaultBranchBigIntErrors(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for complex→*big.Int, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 }
@@ -324,8 +324,8 @@ func TestDefaultBranchBigFloatErrors(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for bool→*big.Float, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 	t.Run("complex128 → error (\"(1+2i)\" is not a valid big.Float)", func(t *testing.T) {
@@ -333,8 +333,8 @@ func TestDefaultBranchBigFloatErrors(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for complex→*big.Float, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 }

--- a/to.chan_test.go
+++ b/to.chan_test.go
@@ -273,8 +273,8 @@ func TestToChanSlice(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -307,8 +307,8 @@ func TestToChanNested(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -319,8 +319,8 @@ func TestChanInvalidDefault(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("int DEFAULT for chan string", func(t *testing.T) {
@@ -328,8 +328,8 @@ func TestChanInvalidDefault(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("chan string DEFAULT for chan int", func(t *testing.T) {
@@ -337,8 +337,8 @@ func TestChanInvalidDefault(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("compatible DEFAULT for chan int does not error", func(t *testing.T) {
@@ -355,8 +355,8 @@ func TestToChanDefaultArm(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for chan struct{} (unsupported kind), got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -1012,8 +1012,8 @@ func TestToChanFuncSliceVariants(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -1056,8 +1056,8 @@ func TestToChanFuncElement(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -1070,8 +1070,8 @@ func TestToChanSliceDefaultArm(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for chan []struct{} (unsupported slice element kind), got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -1083,8 +1083,8 @@ func TestToChanFuncDefaultArm(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for chan Func[struct{}] (unsupported Func return kind), got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -1096,8 +1096,8 @@ func TestToChanFuncSliceDefaultArm(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for chan Func[[]struct{}] (unsupported element kind), got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -1109,8 +1109,8 @@ func TestToChanNestedDefaultArm(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for chan chan struct{} (unsupported nested element kind), got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -1152,8 +1152,8 @@ test: %#v
 				t.Error("1. expected nil, got error", testInfo)
 			} else if err == nil && test.expectErr {
 				t.Error("2. expected error, got nil", testInfo)
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Error("3. expected cast.Error, got different error type", testInfo)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Error("3. expected cast.ErrorUnableToCast, got different error type", testInfo)
 			} else if nil == err && !reflect.DeepEqual(result, test.expect.(TTo)) {
 				t.Errorf("4. expected %v to equal %v %s", test.expect, actual, testInfo)
 			}

--- a/to.duration_test.go
+++ b/to.duration_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bdlm/cast/v2"
 )
 
-
 func TestToEDuration(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -60,8 +59,8 @@ func TestToEDuration(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && result != tc.expect {
 				t.Errorf("expected %v, got %v", tc.expect, result)
 			}
@@ -100,8 +99,8 @@ func TestToEDurationInvalidDefault(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for non-time.Duration DEFAULT, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %T: %v", err, err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 	}
 }
 
@@ -155,8 +154,8 @@ func TestToEDurationStringerDefaultFails(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for unparseable Stringer duration, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %T: %v", err, err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 	}
 }
 
@@ -210,8 +209,8 @@ func TestBigIntToDuration(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && result != tc.expect {
 				t.Errorf("expected %v, got %v", tc.expect, result)
 			}
@@ -230,8 +229,8 @@ func TestDefaultBranchToDuration(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for time.Time→time.Duration, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 	t.Run("bool → error (not a duration string)", func(t *testing.T) {
@@ -239,8 +238,8 @@ func TestDefaultBranchToDuration(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for bool→time.Duration, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 	t.Run("complex128 → error (not a duration string)", func(t *testing.T) {
@@ -248,8 +247,8 @@ func TestDefaultBranchToDuration(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for complex→time.Duration, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 }

--- a/to.float_test.go
+++ b/to.float_test.go
@@ -288,7 +288,7 @@ func TestFloatDefaultBranchError(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for struct→float64, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %T: %v", err, err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 	}
 }

--- a/to.func_test.go
+++ b/to.func_test.go
@@ -275,8 +275,8 @@ func TestToFuncSlice(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -309,8 +309,8 @@ func TestToFuncChan(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -655,8 +655,8 @@ func TestToFuncDefaultWrongType(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for wrong DEFAULT type, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -697,7 +697,7 @@ test: %#v
 				t.Error(1, testInfo)
 			} else if test.expectErr && err == nil {
 				t.Error(2, testInfo)
-			} else if err != nil && !errors.Is(err, cast.Error) {
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
 				t.Error(3, testInfo)
 			} else if nil == err && !reflect.DeepEqual(result, test.expect.(TTo)) {
 				t.Error(4, testInfo)

--- a/to.go
+++ b/to.go
@@ -18,7 +18,7 @@ import (
 )
 
 // To casts the value v to the given type, ignoring any errors. See the ToE
-// documentation more information.
+// documentation for more information.
 func To[TTo Types](v any, o ...Op) TTo {
 	ret, _ := ToE[TTo](v, o...)
 	return ret
@@ -26,16 +26,15 @@ func To[TTo Types](v any, o ...Op) TTo {
 
 // ToE casts the value v to the given type, returning any errors.
 //
-// ops (Ops) is an optional parameter providing flags that can be used to modify
-// the default type conversion behavior. If ops is not provided, the default
-// conversion behavior for a given type is used. Available options depend on the
-// target type, see the documentation for the specific type conversion function
-// for more information.
+// ops is an optional variadic list of [Op] values that control conversion
+// behavior. If omitted, the default conversion behavior for the target type is
+// used. Available options depend on the target type; see the documentation for
+// the specific type conversion function for more information.
 //
 // Complex types have specific default behaviors, for example:
 //
-//   - If the target type is a channel, a channel with a buffer of 1 is created
-//     and the cast value `v` is added to the the channel before it is returned.
+//   - If the target type is a channel, a buffered channel of size 1 is created
+//     and the cast value `v` is sent to the channel before it is returned.
 //
 //   - If the target type is a slice, a slice is created. To pre-allocate
 //     backing capacity set the LENGTH flag: `cast.ToE[[]int](v, cast.Op{cast.LENGTH, 10})`.

--- a/to.go_test.go
+++ b/to.go_test.go
@@ -94,8 +94,8 @@ test: %#v
 				t.Error("1. expected nil, got error", testInfo)
 			} else if err == nil && test.expectErr {
 				t.Error("2. expected error, got nil", testInfo)
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Error("3. expected cast.Error, got different error type", testInfo)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Error("3. expected cast.ErrorUnableToCast, got different error type", testInfo)
 			} else if nil == err && !reflect.DeepEqual(actual, test.expect) {
 				t.Errorf("4. expected %v to equal %v %s", test.expect, actual, testInfo)
 			}
@@ -124,8 +124,8 @@ func TestToEDefaultCaseConcreteError(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for concrete error type → ToE default branch, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -137,8 +137,8 @@ func TestToEDefaultCaseConcreteStringer(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for concrete Stringer type → ToE default branch, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -406,7 +406,10 @@ func TestPointerDerefLoop(t *testing.T) {
 	})
 
 	t.Run("*anonymous struct → struct", func(t *testing.T) {
-		src := &struct{ X int; Y string }{X: 3, Y: "anon"}
+		src := &struct {
+			X int
+			Y string
+		}{X: 3, Y: "anon"}
 		got, err := cast.ToE[ptrDerefStruct](src)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -423,8 +426,8 @@ func TestPointerDerefLoop(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for nil struct source, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 

--- a/to.int_test.go
+++ b/to.int_test.go
@@ -439,8 +439,8 @@ func TestToIntStructSource(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for struct{} source → int, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -451,8 +451,8 @@ func TestStrToIntDefaultWrongType(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for string DEFAULT on int target, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -673,7 +673,7 @@ func TestStrToIntDefaultWrongType2(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for wrong DEFAULT type, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }

--- a/to.map_test.go
+++ b/to.map_test.go
@@ -33,8 +33,8 @@ test: %#v
 			t.Error("1. expected nil, got error", testInfo)
 		} else if err == nil && test.expectErr {
 			t.Error("2. expected error, got nil", testInfo)
-		} else if err != nil && !errors.Is(err, cast.Error) {
-			t.Error("3. expected cast.Error, got different error type", testInfo)
+		} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Error("3. expected cast.ErrorUnableToCast, got different error type", testInfo)
 		} else if err == nil && !reflect.DeepEqual(actual, test.expect) {
 			t.Errorf("4. expected %v to equal %v %s", test.expect, actual, testInfo)
 		}
@@ -285,8 +285,8 @@ func TestMapInvalidDefault(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("int DEFAULT for map[string]string", func(t *testing.T) {
@@ -294,8 +294,8 @@ func TestMapInvalidDefault(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("map[string]string DEFAULT for map[string]int", func(t *testing.T) {
@@ -303,8 +303,8 @@ func TestMapInvalidDefault(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("compatible DEFAULT for map[string]int does not error", func(t *testing.T) {
@@ -324,8 +324,8 @@ func TestMapFromMapErrors(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for uncastable map key, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("value cast failure errors", func(t *testing.T) {
@@ -335,8 +335,8 @@ func TestMapFromMapErrors(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for uncastable map value, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -347,8 +347,8 @@ func TestMapFromSliceValueError(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for uncastable slice element, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -359,8 +359,8 @@ func TestMapFromScalarSourceError(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for scalar source → map, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -368,7 +368,7 @@ func TestMapFromScalarSourceError(t *testing.T) {
 // (Bool, Uint, Float, Complex, String) for unexported fields when PRIVATE=true.
 func TestMapFromStructUnexportedScalars(t *testing.T) {
 	type allPrivate struct {
-		PubName    string
+		PubName     string
 		privBool    bool       //nolint:unused
 		privUint    uint       //nolint:unused
 		privFloat   float64    //nolint:unused
@@ -426,8 +426,8 @@ func TestMapFromStructUnextractableField(t *testing.T) {
 		if err == nil {
 			t.Error("expected error in strict mode for non-scalar unexported field, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -521,8 +521,8 @@ func TestMapFromStructKeyIncompatible(t *testing.T) {
 		if err == nil {
 			t.Error("expected error in strict mode for incompatible key type, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -564,8 +564,8 @@ func TestCollectStructFieldsEmbeddedError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from embedded struct recursion, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -581,8 +581,8 @@ func TestCollectStructFieldsMapValTypeError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from map-valtype nested struct failure, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -600,8 +600,8 @@ func TestCollectStructFieldsAnyValTypeNestedError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from nested mapFromStruct failure (any valType), got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -625,8 +625,8 @@ func TestMapFromStructNonEmptyInterfaceValType(t *testing.T) {
 	// testStringer is defined in to.string_test.go (same package cast_test).
 	type notStringer struct{ n int }
 	type mixedStringers struct {
-		Name    testStringer
-		NoStr   notStringer // struct, does NOT implement fmt.Stringer
+		Name  testStringer
+		NoStr notStringer // struct, does NOT implement fmt.Stringer
 	}
 	src := mixedStringers{Name: testStringer{"hello"}, NoStr: notStringer{42}}
 
@@ -649,8 +649,8 @@ func TestMapFromStructNonEmptyInterfaceValType(t *testing.T) {
 		if err == nil {
 			t.Error("expected error in strict mode for non-Stringer struct field, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -688,8 +688,8 @@ func TestMapFromStructNestedStructToScalar(t *testing.T) {
 		if err == nil {
 			t.Error("expected error: struct→int cast fails in strict mode")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("nested struct cast to int fails non-strict: field skipped", func(t *testing.T) {
@@ -746,8 +746,8 @@ func TestMapFromSliceKeyCastError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error casting slice index to struct{} key, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -769,8 +769,8 @@ func TestToMapDefaultWithStrict(t *testing.T) {
 	if err == nil {
 		t.Error("expected error in strict mode for unconvertible field, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %T: %v", err, err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 	}
 	if !reflect.DeepEqual(result, def) {
 		t.Errorf("expected default %v, got %v", def, result)

--- a/to.net_test.go
+++ b/to.net_test.go
@@ -49,8 +49,8 @@ func TestToENetIP(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && !result.Equal(tc.expect) {
 				t.Errorf("expected %v, got %v", tc.expect, result)
 			}
@@ -90,8 +90,8 @@ func TestToENetIPInvalidDefault(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for non-net.IP DEFAULT, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %T: %v", err, err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 	}
 }
 
@@ -112,8 +112,8 @@ func TestToENetIPDefaultCase(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for int→net.IP (not a valid IP string), got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 }
@@ -202,8 +202,8 @@ func TestToENetIPNewSources(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && !result.Equal(tc.expect) {
 				t.Errorf("expected %v, got %v", tc.expect, result)
 			}

--- a/to.regexp_test.go
+++ b/to.regexp_test.go
@@ -33,8 +33,8 @@ func TestToERegexp(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && result.String() != tc.pattern {
 				t.Errorf("expected pattern %q, got %q", tc.pattern, result.String())
 			}
@@ -74,8 +74,8 @@ func TestToERegexpInvalidDefault(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for non-*regexp.Regexp DEFAULT, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %T: %v", err, err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 	}
 }
 
@@ -106,8 +106,8 @@ func TestToERegexpDefaultCase(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for invalid regexp pattern via default branch, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 }

--- a/to.slice.go
+++ b/to.slice.go
@@ -6,8 +6,7 @@ import (
 	"slices"
 )
 
-// toSlice returns a slice containing the specified reflect.Value type
-// containing the from value.
+// toSlice converts val to a slice whose element type is described by to.
 //
 // Options:
 //   - DEFAULT: slice, default return value on error.

--- a/to.slice_test.go
+++ b/to.slice_test.go
@@ -115,7 +115,7 @@ func TestSliceToUintSlice(t *testing.T) {
 		{in: []uint32{1, 30, 10, 0, 1}, expect: []uint{1, 30, 10, 0, 1}, err: nil, expectErr: false},
 		{in: 1, expect: []uint{1}, err: nil, expectErr: false},
 		{in: "1", expect: []uint{1}, err: nil, expectErr: false},
-		{in: -1, expect: []uint{}, err: nil, expectErr: true},  // negative signed → unsigned errors
+		{in: -1, expect: []uint{}, err: nil, expectErr: true},   // negative signed → unsigned errors
 		{in: "-1", expect: []uint{}, err: nil, expectErr: true}, // negative string → unsigned errors
 		{in: []float32{1.1}, expect: []uint{1}, err: nil, expectErr: false},
 		{in: []string{"1.1"}, expect: []uint{1}, err: nil, expectErr: false},
@@ -392,8 +392,8 @@ func TestSliceLengthErrors(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for invalid LENGTH value, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("negative LENGTH errors", func(t *testing.T) {
@@ -401,8 +401,8 @@ func TestSliceLengthErrors(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for negative LENGTH, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -413,8 +413,8 @@ func TestSliceInvalidDefault(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("int DEFAULT for []string", func(t *testing.T) {
@@ -422,8 +422,8 @@ func TestSliceInvalidDefault(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]string DEFAULT for []int", func(t *testing.T) {
@@ -431,8 +431,8 @@ func TestSliceInvalidDefault(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("compatible DEFAULT for []int does not error", func(t *testing.T) {
@@ -451,62 +451,62 @@ func TestToSliceElementErrors(t *testing.T) {
 
 	t.Run("[]bool element error", func(t *testing.T) {
 		_, err := cast.ToE[[]bool](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]complex64 element error", func(t *testing.T) {
 		_, err := cast.ToE[[]complex64](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]complex128 element error", func(t *testing.T) {
 		_, err := cast.ToE[[]complex128](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]float32 element error", func(t *testing.T) {
 		_, err := cast.ToE[[]float32](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]float64 element error", func(t *testing.T) {
 		_, err := cast.ToE[[]float64](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]int element error", func(t *testing.T) {
 		_, err := cast.ToE[[]int](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]int8 element error", func(t *testing.T) {
 		_, err := cast.ToE[[]int8](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]int16 element error", func(t *testing.T) {
 		_, err := cast.ToE[[]int16](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]int32 element error", func(t *testing.T) {
 		_, err := cast.ToE[[]int32](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("[]int64 element error", func(t *testing.T) {
 		_, err := cast.ToE[[]int64](bad)
-		if err == nil || !errors.Is(err, cast.Error) {
-			t.Fatalf("expected cast.Error, got %v", err)
+		if err == nil || !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Fatalf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -573,8 +573,8 @@ func TestMapToSlice(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for unconvertible map value, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -786,8 +786,8 @@ func TestJSONStringToSlice(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for unconvertible JSON element, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -822,8 +822,8 @@ test: %#v
 				t.Error("1. expected nil, got error", testInfo)
 			} else if nil == err && test.expectErr {
 				t.Error("2. expected error, got nil", testInfo)
-			} else if nil != err && !errors.Is(err, cast.Error) {
-				t.Error("3. expected cast.Error, got different error type", testInfo)
+			} else if nil != err && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Error("3. expected cast.ErrorUnableToCast, got different error type", testInfo)
 			} else if nil == err && !reflect.DeepEqual(actual, test.expect) {
 				t.Errorf("4. expected %v (%T) to equal %v (%T)\n%s", test.expect, test.expect, actual, actual, testInfo)
 			}

--- a/to.string_test.go
+++ b/to.string_test.go
@@ -51,8 +51,8 @@ func TestToErrorTarget(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("int input fails", func(t *testing.T) {
@@ -60,8 +60,8 @@ func TestToErrorTarget(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -93,8 +93,8 @@ func TestToStdErrorTarget(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("non-error string input fails", func(t *testing.T) {
@@ -102,8 +102,8 @@ func TestToStdErrorTarget(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -134,8 +134,8 @@ func TestToStringerTarget(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("int does not satisfy fmt.Stringer, fails", func(t *testing.T) {
@@ -143,8 +143,8 @@ func TestToStringerTarget(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("bdlm error has Format but not String, fails", func(t *testing.T) {
@@ -154,8 +154,8 @@ func TestToStringerTarget(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -268,8 +268,8 @@ func TestStringFromMap(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for unmarshalable map, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -315,8 +315,8 @@ func TestStringFromStructJSONMarshal(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for unmarshalable struct, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -331,8 +331,8 @@ func TestStringJSONOptionUnmarshalableSource(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for JSON option with unmarshalable source, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 

--- a/to.struct.go
+++ b/to.struct.go
@@ -16,7 +16,7 @@ func ToStruct[T any](from any, ops ...Op) T {
 // ToStructE casts from into a struct of type T, returning any errors.
 //
 // T must be a struct type. The source may be a map with keys convertible to
-// string, or another struct whose field names overlap with T.
+// string, or a struct or *struct whose field names overlap with T.
 //
 // Field matching is case-sensitive and tag-aware. The lookup key for each
 // target field is resolved by checking a cast tag first, then a json tag,
@@ -34,16 +34,16 @@ func ToStructE[T any](from any, ops ...Op) (T, error) {
 	var zero T
 	to := reflect.ValueOf(&zero).Elem()
 	if to.Kind() != reflect.Struct {
-		return zero, fmt.Errorf("%w, %w", Error, fmt.Errorf("ToStructE requires a struct target type, got %T", zero))
+		return zero, fmt.Errorf("%w, %w", ErrorUnableToCast, fmt.Errorf("ToStructE requires a struct target type, got %T", zero))
 	}
 	options := parseOps(ops)
 	raw, err := toStruct(to, from, options)
 	if err != nil {
-		return zero, fmt.Errorf("%w, %w", Error, err)
+		return zero, fmt.Errorf("%w, %w", ErrorUnableToCast, err)
 	}
 	result, ok := raw.(T)
 	if !ok {
-		return zero, fmt.Errorf("%w, %w", Error, fmt.Errorf("cast failed: returned %T, want %T", raw, zero))
+		return zero, fmt.Errorf("%w, %w", ErrorUnableToCast, fmt.Errorf("cast failed: returned %T, want %T", raw, zero))
 	}
 	return result, nil
 }

--- a/to.struct_test.go
+++ b/to.struct_test.go
@@ -35,8 +35,8 @@ test: %#v
 			t.Error("1. expected nil, got error", testInfo)
 		} else if err == nil && test.expectErr {
 			t.Error("2. expected error, got nil", testInfo)
-		} else if err != nil && !errors.Is(err, cast.Error) {
-			t.Error("3. expected cast.Error, got different error type", testInfo)
+		} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Error("3. expected cast.ErrorUnableToCast, got different error type", testInfo)
 		} else if err == nil && !reflect.DeepEqual(actual, test.expect) {
 			t.Errorf("4. expected %v to equal %v %s", test.expect, actual, testInfo)
 		}
@@ -92,14 +92,14 @@ type embeddedPtrStruct struct {
 
 func TestStructFlat(t *testing.T) {
 	testStructCase[flatStruct](t, testCase{
-		in: map[string]any{"Name": "Alice", "Age": "30", "Score": "9.5", "Valid": "true"},
+		in:     map[string]any{"Name": "Alice", "Age": "30", "Score": "9.5", "Valid": "true"},
 		expect: flatStruct{Name: "Alice", Age: 30, Score: 9.5, Valid: true},
 	})
 }
 
 func TestStructFlatStringMap(t *testing.T) {
 	testStructCase[flatStruct](t, testCase{
-		in: map[string]string{"Name": "Bob", "Age": "25", "Score": "7.1", "Valid": "false"},
+		in:     map[string]string{"Name": "Bob", "Age": "25", "Score": "7.1", "Valid": "false"},
 		expect: flatStruct{Name: "Bob", Age: 25, Score: 7.1, Valid: false},
 	})
 }
@@ -130,8 +130,8 @@ func TestStructUnknownKeysStrict(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for unknown key in STRICT mode, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -146,8 +146,8 @@ func TestStructMissingKeyStrict(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for missing key in STRICT mode, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -169,8 +169,8 @@ func TestStructUnconvertibleFieldStrict(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for unconvertible field in STRICT mode, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -180,8 +180,8 @@ func TestStructUnconvertibleFieldStrict(t *testing.T) {
 func TestStructNested(t *testing.T) {
 	testStructCase[nestedStruct](t, testCase{
 		in: map[string]any{
-			"Title": "test",
-			"Inner": map[string]any{"Name": "x", "Age": "1", "Score": "2.0", "Valid": "true"},
+			"Title":  "test",
+			"Inner":  map[string]any{"Name": "x", "Age": "1", "Score": "2.0", "Valid": "true"},
 			"Counts": []any{1, 2, 3},
 		},
 		expect: nestedStruct{
@@ -316,8 +316,8 @@ func TestStructInvalidTargetType(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for non-struct target type, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -328,8 +328,8 @@ func TestStructNilSource(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for nil source, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }

--- a/to.time_numeric_test.go
+++ b/to.time_numeric_test.go
@@ -64,8 +64,8 @@ func TestBigTypesToTime(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && !result.Equal(tc.expect) {
 				t.Errorf("expected %v, got %v", tc.expect, result)
 			}
@@ -294,8 +294,8 @@ func TestStringerToTime(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for unparseable Stringer, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 }

--- a/to.time_test.go
+++ b/to.time_test.go
@@ -60,8 +60,8 @@ func TestToETime(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && !result.Equal(tc.expect) {
 				t.Errorf("expected %v, got %v", tc.expect, result)
 			}
@@ -100,8 +100,8 @@ func TestToETimeInvalidDefault(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for non-time.Time DEFAULT, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %T: %v", err, err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 	}
 }
 
@@ -160,8 +160,8 @@ func TestToETimeCustomFormat(t *testing.T) {
 		if err == nil {
 			t.Error("expected error: with custom FORMAT, standard formats must not be tried as a fallback")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %T: %v", err, err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 		}
 	})
 }

--- a/to.type.go
+++ b/to.type.go
@@ -7,11 +7,31 @@ import (
 
 // Sentinel errors and reusable format strings used throughout the package.
 var (
-	Error                    = fmt.Errorf("unable to cast value")
-	ErrorSignedToUnsigned    = fmt.Errorf("cannot cast signed value to unsigned integer")
-	ErrorInvalidOption       = "invalid %s value '%v'"
+	// ErrorUnableToCast is a sentinel error returned when a value cannot be
+	// cast to the requested type. It is used as a fallback error message in
+	// conversion operations that do not provide more specific error details.
+	ErrorUnableToCast = fmt.Errorf("unable to cast value")
+
+	// ErrorSignedToUnsigned is returned when a negative value is cast to an
+	// unsigned integer type and the ABS flag is not set.
+	ErrorSignedToUnsigned = fmt.Errorf("cannot cast signed value to unsigned integer")
+
+	// ErrorInvalidOption is a format string (not an error value) used to build
+	// error messages when an Op flag carries an unexpected value type.
+	ErrorInvalidOption = "invalid %s value '%v'"
+
+	// ErrorStrErrorCastingFunc is a format string (not an error value) used
+	// when an element cast fails inside a Func[T] closure generator.
 	ErrorStrErrorCastingFunc = "error casting %T to %T during function generation"
-	ErrorStrUnableToCast     = "unable to cast %#.10v of type %T to %T"
+
+	// ErrorStrUnableToCast is a format string (not an error value) used when
+	// a value cannot be converted to the requested target type.
+	ErrorStrUnableToCast = "unable to cast %#.10v of type %T to %T"
+
+	// Error is a deprecated alias for [ErrorUnableToCast].
+	//
+	// Deprecated: use [ErrorUnableToCast].
+	Error = ErrorUnableToCast
 )
 
 // Flag is the key type for conversion options passed to [To] and [ToE].
@@ -28,13 +48,13 @@ type Op struct {
 //
 // Global flags propagate through the full conversion tree and are preserved by
 // [ops.Global]. They apply the same way at every level of a nested conversion:
-//   - ABS, JSON, LENGTH, PRIVATE, STRICT, UNIQUE_VALUES
+//   - ABS, FORMAT, JSON, LENGTH, PRIVATE, STRICT, UNIQUE_VALUES
 //
 // Local flags apply only to the conversion they are passed to and are stripped
 // by [ops.Global]. Container converters read their own local flags, then pass
 // [ops.Global] to element-level casts so the local flags do not leak into
 // nested conversions where they carry no meaning or the wrong type:
-//   - DEFAULT, DUPLICATE_KEY_ERROR
+//   - DECODE, DEFAULT, DUPLICATE_KEY_ERROR
 const (
 	DEFAULT Flag = iota // TTo,  LOCAL  — value to return on error; type-specific, not passed to nested casts
 
@@ -53,9 +73,9 @@ const (
 // struct is used instead of a map so that the common zero-options path
 // allocates nothing and bool-flag checks are plain field reads.
 //
-// defaultVal and lengthVal preserve the original Op.Val for type-checking
-// and error messages at each call site; all other flags are pre-parsed to
-// their concrete bool type by parseOps.
+// defaultVal and lengthVal preserve the original Op.Val for type-checking and
+// error messages. formatVal and decodeVal are stored as pre-parsed strings.
+// All bool flags are parsed eagerly by parseOps.
 type ops struct {
 	hasDefault bool
 	defaultVal any // DEFAULT value; meaningful only when hasDefault is true
@@ -78,9 +98,9 @@ type ops struct {
 }
 
 // Global returns a copy of ops containing only the flags that apply
-// universally across all target types. Local flags (DEFAULT,
-// DUPLICATE_KEY_ERROR) are dropped; global flags (ABS, JSON, LENGTH, PRIVATE,
-// STRICT, UNIQUE_VALUES) are retained.
+// universally across all target types. Local flags (DECODE, DEFAULT,
+// DUPLICATE_KEY_ERROR) are dropped; global flags (ABS, FORMAT, JSON, LENGTH,
+// PRIVATE, STRICT, UNIQUE_VALUES) are retained.
 //
 // Container converters call this when passing ops to element-level casts so
 // that a container's own local flags do not leak into nested conversions where
@@ -168,8 +188,9 @@ func (o ops) List() []Op {
 }
 
 // parseOps collapses the public variadic []Op into the internal ops struct
-// used by all conversion functions. Bool flags are parsed eagerly; DEFAULT
-// and LENGTH preserve their raw Val for type-checking at each call site.
+// used by all conversion functions. Bool flags are parsed eagerly; DEFAULT and
+// LENGTH preserve their raw Val for type-checking at each call site; FORMAT and
+// DECODE are stored as normalized strings.
 func parseOps(o []Op) ops {
 	if len(o) == 0 {
 		return ops{}
@@ -247,7 +268,7 @@ type Types interface {
 // effectively unconstrained — all types satisfy it. This is intentional:
 // interface targets like error and fmt.Stringer need to be expressible as TTo,
 // and there is no way to enumerate all interface types. Unsupported kinds
-// (struct, pointer, etc.) are rejected at runtime by ToE's dispatch switch.
+// are rejected at runtime by ToE's dispatch switch.
 type Tbase interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 |
 		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
@@ -282,6 +303,9 @@ type Tchan interface {
 		~chan chan Tbase
 }
 
+// Tmap covers map types whose keys are any [Tbase] type and whose values are
+// either a scalar [Tbase] or a slice of scalars. Named types with a matching
+// underlying map type (e.g. type Attrs map[string]any) also satisfy Tmap.
 type Tmap interface {
 	~map[Tbase]Tbase |
 		~map[Tbase][]int |

--- a/to.types_test.go
+++ b/to.types_test.go
@@ -170,8 +170,8 @@ func TestNamedIntSliceType(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for bad element, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -198,8 +198,8 @@ func TestMapWithSliceValues(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for bad element, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -213,8 +213,8 @@ func TestMapInterfaceValueNonAssignable(t *testing.T) {
 	if err == nil {
 		t.Error("expected error: int does not implement fmt.Stringer")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -373,8 +373,8 @@ func TestCastToKindAllScalars(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for unsupported kind, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -417,8 +417,8 @@ func TestCastToTypeChanBranch(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for bad LENGTH, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 	t.Run("LENGTH zero errors (size < 1)", func(t *testing.T) {
@@ -426,8 +426,8 @@ func TestCastToTypeChanBranch(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for LENGTH=0, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -449,8 +449,8 @@ func TestCastToSliceTypeDefaultBranch(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for bad scalar source, got nil")
 		}
-		if !errors.Is(err, cast.Error) {
-			t.Errorf("expected cast.Error, got %v", err)
+		if !errors.Is(err, cast.ErrorUnableToCast) {
+			t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 		}
 	})
 }
@@ -475,8 +475,8 @@ func TestCastToTypeFuncUnsupportedType(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported func type, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -487,8 +487,8 @@ func TestCastToTypeFuncElementError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for uncastable Func element, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -499,8 +499,8 @@ func TestCastToTypeChanElementError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for uncastable Chan element, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -527,8 +527,8 @@ func TestToEDefaultElseBranch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported struct TTo, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -554,8 +554,8 @@ func TestToBoolDefaultError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unparseable bool source, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 
@@ -568,8 +568,8 @@ func TestToComplexDefaultError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unparseable complex source, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %v", err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %v", err)
 	}
 }
 

--- a/to.url_test.go
+++ b/to.url_test.go
@@ -42,8 +42,8 @@ func TestToEURL(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			} else if err == nil && tc.expectErr {
 				t.Error("expected error, got nil")
-			} else if err != nil && !errors.Is(err, cast.Error) {
-				t.Errorf("expected cast.Error, got %T: %v", err, err)
+			} else if err != nil && !errors.Is(err, cast.ErrorUnableToCast) {
+				t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 			} else if err == nil && result.String() != tc.expectStr {
 				t.Errorf("expected %q, got %q", tc.expectStr, result.String())
 			}
@@ -83,8 +83,8 @@ func TestToEURLInvalidDefault(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for non-*url.URL DEFAULT, got nil")
 	}
-	if !errors.Is(err, cast.Error) {
-		t.Errorf("expected cast.Error, got %T: %v", err, err)
+	if !errors.Is(err, cast.ErrorUnableToCast) {
+		t.Errorf("expected cast.ErrorUnableToCast, got %T: %v", err, err)
 	}
 }
 

--- a/util.reflect.go
+++ b/util.reflect.go
@@ -128,6 +128,15 @@ func castToKind(v any, kind reflect.Kind, ops ops) (reflect.Value, error) {
 }
 
 // castToType casts v to the type t and returns the result as a reflect.Value.
+// Dispatch order:
+//  1. Named types — checked in namedConverters before the kind switch.
+//  2. Interface — assignability-checked and returned as-is.
+//  3. Map, Slice — delegated to toMap / toSlice.
+//  4. Func — requires zero-arg, one-return signature; return type is cast recursively.
+//  5. Chan — element is cast recursively; a buffered channel of the target type is returned.
+//  6. Pointer — element type is cast recursively; a new pointer is allocated.
+//  7. Struct — delegated to castToStructType.
+//  8. Scalars — delegated to castToKind with a ConvertibleTo fallback for named types.
 func castToType(v any, t reflect.Type, ops ops) (reflect.Value, error) {
 	// Named types have dedicated converters; consult the table before the
 	// generic kind dispatch below so that adding a new named type only


### PR DESCRIPTION
### Added

- Doc comments added to previously undocumented exported and internal symbols:
  - `Tmap` type
  - `ErrorSignedToUnsigned`, `ErrorInvalidOption`, `ErrorStrErrorCastingFunc`, `ErrorStrUnableToCast` (clarifying the string vars are format strings, not error values)
  - `castToType` — all 8 dispatch cases documented
- New godoc examples: `ExampleTo_map`, `ExampleTo_struct`, `ExampleToE_mapDuplicateKeyError`, `ExampleToE_structNested`, `ExampleToE_structStrict`, `ExampleToE_mapToPrivateStruct`.

### Changed

- Renamed the sentinel error variable `Error` to `ErrorUnableToCast`. `Error` is retained as a deprecated alias with a `// Deprecated:` godoc annotation for backward compatibility.
- Example function suffixes converted from `snake_case` to `camelCase` (e.g. `ExampleToE_mapFromMap`) so all examples appear in godoc. Suffixes containing underscores are silently dropped by godoc.

### Fixed

- `ToE` doc referenced non-existent type `Ops` (correct type is `Op`) and contained double word "the the" — corrected.
- `ToStructE` doc omitted `*struct` as a valid source type — corrected.
- `toSlice` doc was circular and meaningless — rewritten.
- `ops.Global` doc omitted `FORMAT` from the global flag list and `DECODE` from the local flag list — corrected.
- `parseOps` doc omitted `FORMAT` and `DECODE` from its description of preserved values — corrected.
- `ops` struct doc incorrectly stated all non-default flags are pre-parsed to `bool`; `FORMAT` and `DECODE` are stored as strings — corrected.
- `TestPointerDerefLoop` "pointer-to-interface" sub-test used `errors.New` whose concrete pointer type is opaque; replaced with a local `ptrReceiverError` type that has `Error()` on `*T` only, making the pointer-receiver guard explicit and self-documenting.

